### PR TITLE
Ignore modules which we didn't see during loading

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 				var shouldExtract = !!(options.allChunks || chunk.initial);
 				var text = [];
 				async.forEach(chunk.modules, function(module, callback) {
-					var meta = module.meta[__dirname];
+					var meta = module.meta && module.meta[__dirname];
 					if(meta) {
 						var wasExtracted = typeof meta.text === "string";
 						if(shouldExtract !== wasExtracted) {


### PR DESCRIPTION
This can be the case when we have multiple entry points and so we can see a 
synthesized module during "optimize-tree" phase.
