### PR TITLE
Expose addText(text, options) in loader context

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 	var options = this.options;
 	compiler.plugin("this-compilation", function(compilation) {
 		compilation.plugin("normal-module-loader", function(loaderContext, module) {
-			loaderContext[__dirname] = function(text, opt) {
+			loaderContext[__dirname] = loaderContext.addText = function(text, opt) {
 				if(typeof text !== "string" && text !== null)
 					throw new Error("Exported value is not a string.");
 				module.meta[__dirname] = {


### PR DESCRIPTION
This PR isn't meant to be merged because it is obviously incorrect (in the
context of multiple plugin instances). But it illustrates the feature I want
from extract-text-webpack-plugin.

I have JS source files which I want to use in my app but also I want to extract
CSS from them (which is encoded in some way, see
https://github.com/SanderSpies/IntegratedCSS). So the loader for such files
while processing them also need to emit some CSS:

```
function loader(source) {
  this.cacheable();
  var transformed = transform(source, name);
  if (transformed.css.length > 0) {
    this.addText(transformed.css);
  }
  return transformed.source;
}
```

I see, `id` of the plugin is not used at all now. Probably we can add different
methods for different plugin instances? For example for
`ExtractTextPlugin('CSS', 'styles.css')` we add `text.CSS`, for
`ExtractTextPlugin('someText', 'some.text')` we add `text.someText` and so on?
We also would allow only a single instance w/o any id and will check for
conflicting ones? I'm probably missing something...
