### PR TITLE
Use Compilation.getPath instead of replacing regexes manually

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,10 +143,9 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 			var assetContents = {};
 			contents.forEach(function(item) {
 				var chunk = item.chunk;
-				var file = filename
-					.replace(Template.REGEXP_NAME, chunk.name || chunk.id)
-					.replace(Template.REGEXP_HASH, compilation.hash)
-					.replace(Template.REGEXP_CHUNKHASH, chunk.renderedHash);
+				var file = compilation.getPath(filename, {
+					chunk: chunk
+				});
 				assetContents[file] = (assetContents[file] || []).concat(item.content);
 				chunk.files.push(file);
 			});


### PR DESCRIPTION
Since webpack/webpack#427, the REGEXP properties are no longer exposed on Template, and it is instead expected to call one of the built-in mechanisms for templating an asset path.
