### PR TITLE
Make plugin re-entrant

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -18,11 +18,11 @@ module.exports.pitch = function(request, preReq, data) {
 	this.addDependency(this.resourcePath);
 	// We already in child compiler, return empty bundle
 	if(this[__dirname] === undefined) {
-	  throw new Error(
-	    '"extract-text-webpack-plugin" loader is used without the corresponding plugin, ' +
-	    'refer to https://github.com/webpack/extract-text-webpack-plugin for the usage example'
-	  );
-  } else if(this[__dirname] === false) {
+		throw new Error(
+			'"extract-text-webpack-plugin" loader is used without the corresponding plugin, ' +
+			'refer to https://github.com/webpack/extract-text-webpack-plugin for the usage example'
+		);
+	} else if(this[__dirname] === false) {
 		return "";
 	} else if(this[__dirname](null, query)) {
 		if(query.omit) {


### PR DESCRIPTION
This disallows spawning child compilers from a child compiler. Fixes #17.
