### PR TITLE
feat: enable source maps based on webpack config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 2
+
+# Matches the exact files either package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
 		loaders: [
 			{ test: /\.css$/, loader: ExtractTextPlugin.extract(
 				"style-loader",
-				"css-loader?sourceMap",
+				"css-loader",
 				{
 					publicPath: "../"
 				}
@@ -23,7 +23,6 @@ module.exports = {
 			{ test: /\.png$/, loader: "file-loader" }
 		]
 	},
-	devtool: "sourcemap",
 	plugins: [
 		new ExtractTextPlugin("css/[name].css?[hash]-[chunkhash]-[contenthash]-[name]", {
 			disable: false,

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var ModuleFilenameHelpers = require("webpack/lib/ModuleFilenameHelpers");
 var ExtractedModule = require("./ExtractedModule");
 var Chunk = require("webpack/lib/Chunk");
 var loaderUtils = require("loader-utils");
+var sourceMapSupport = require("./lib/SourceMapSupport");
 
 var nextId = 0;
 
@@ -92,6 +93,11 @@ ExtractTextPlugin.prototype.extract = function(before, loader, options) {
 
 ExtractTextPlugin.prototype.apply = function(compiler) {
 	var options = this.options;
+
+	if(compiler.options.devtool) {
+		compiler.options.module.loaders = sourceMapSupport.applyParam(compiler.options.module.loaders);
+	}
+
 	compiler.plugin("this-compilation", function(compilation) {
 		var extractCompilation = new ExtractTextPluginCompilation();
 		compilation.plugin("normal-module-loader", function(loaderContext, module) {

--- a/lib/SourceMapSupport.js
+++ b/lib/SourceMapSupport.js
@@ -1,0 +1,27 @@
+function applyToLoaders(loaders) {
+	return loaders.map(function(loader){
+		if (loader.indexOf('?') !== -1) {
+			return loader;
+		}
+
+		return loader.replace(/css(-loader)?/, '$&?sourceMap');
+	});
+}
+
+function splitAndApplyToLoader(loader) {
+	var loaders = loader.split('!');
+	return applyToLoaders(loaders).join('!');
+}
+
+module.exports = {
+	applyParam: function(loaders) {
+		return loaders.map(function(loader){
+			if (loader.loader) {
+				loader.loader = splitAndApplyToLoader(loader.loader);
+			} else {
+				loader.loaders = applyToLoaders(loader.loaders);
+			}
+			return loader;
+		});
+	}
+};

--- a/package.json
+++ b/package.json
@@ -1,31 +1,36 @@
 {
-	"name": "extract-text-webpack-plugin",
-	"version": "0.3.8",
-	"author": "Tobias Koppers @sokra",
-	"description": "Extract text from bundle into a file.",
-	"peerDependencies": {
-		"webpack": "^1.4.2"
-	},
-	"dependencies": {
-		"async": "~0.2.10",
-		"source-map": "~0.1.38",
-		"loader-utils": "~0.2.3"
-	},
-	"devDependencies": {
-		"file-loader": "*",
-		"style-loader": "*",
-		"css-loader": "*",
-		"webpack": "*"
-	},
-	"homepage": "http://github.com/webpack/extract-text-webpack-plugin",
-	"repository": {
-		"type": "git",
-		"url": "http://github.com/webpack/extract-text-webpack-plugin.git"
-	},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://www.opensource.org/licenses/mit-license.php"
-		}
-	]
+  "name": "extract-text-webpack-plugin",
+  "version": "0.3.8",
+  "author": "Tobias Koppers @sokra",
+  "description": "Extract text from bundle into a file.",
+  "peerDependencies": {
+    "webpack": "^1.4.2"
+  },
+  "dependencies": {
+    "async": "~0.2.10",
+    "source-map": "~0.1.38",
+    "loader-utils": "~0.2.3"
+  },
+  "devDependencies": {
+    "css-loader": "*",
+    "file-loader": "*",
+    "mocha": "^2.1.0",
+    "should": "^5.0.1",
+    "style-loader": "*",
+    "webpack": "*"
+  },
+  "homepage": "http://github.com/webpack/extract-text-webpack-plugin",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/webpack/extract-text-webpack-plugin.git"
+  },
+  "scripts": {
+    "test": "mocha --reporter spec"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ]
 }

--- a/test/SourceMapSupport.test.js
+++ b/test/SourceMapSupport.test.js
@@ -1,0 +1,65 @@
+var should = require('should');
+var sourceMapSupport = require('../lib/SourceMapSupport');
+
+describe('SourceMapSupportTestCases', function() {
+	it('should add sourceMap query parameter to "css-loader" [loader string]', function() {
+		var loaders = [{
+			loader: 'style-loader!css-loader!less-loader'
+		}];
+
+		var result = sourceMapSupport.applyParam(loaders);
+		result[0].loader.should.equal('style-loader!css-loader?sourceMap!less-loader');
+	});
+
+	it('should add sourceMap query parameter to "css-loader" [loaders array]', function() {
+		var loaders = [{
+			loaders: [
+				'style-loader',
+				'css-loader',
+				'less-loader'
+			]
+		}];
+
+		var result = sourceMapSupport.applyParam(loaders);
+		should.deepEqual([
+			'style-loader',
+			'css-loader?sourceMap',
+			'less-loader'
+		], result[0].loaders);
+	});
+
+	it('should add sourceMap query parameter to "css" [loader string]', function() {
+		var loaders = [{
+			loader: 'style!css!less'
+		}];
+
+		var result = sourceMapSupport.applyParam(loaders);
+		result[0].loader.should.equal('style!css?sourceMap!less');
+	});
+
+	it('should add sourceMap query parameter to "css" [loaders array]', function() {
+		var loaders = [{
+			loaders: [
+				'style',
+				'css',
+				'less'
+			]
+		}];
+
+		var result = sourceMapSupport.applyParam(loaders);
+		should.deepEqual([
+			'style',
+			'css?sourceMap',
+			'less'
+		], result[0].loaders);
+	});
+
+	it('should not add sourceMap query parameter to "css-loader" with pre-existing params [loader string]', function() {
+		var loaders = [{
+			loader: 'style-loader!css-loader?blah!less-loader'
+		}];
+
+		var result = sourceMapSupport.applyParam(loaders);
+		result[0].loader.should.equal('style-loader!css-loader?blah!less-loader');
+	});
+});


### PR DESCRIPTION
Source-maps do not work for CSS when you base64 encode them, yet it
would be nice to to facilitate dynamically applying source-maps using
`webpack -d`. This will apply the sourceMap query param to the
css-loader if a devtool option is selected in the webpack config.

Relates to webpack/less-loader#36
Relates to webpack/css-loader#40
