### PR TITLE
feat: allow to log invalid orders as warnings instead of errors via option

### DIFF
--- a/index.js
+++ b/index.js
@@ -284,8 +284,9 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 				if(extractedChunk.modules.length) {
 					extractedChunk.modules.sort(function(a, b) {
 						if(isInvalidOrder(a, b)) {
-							compilation.errors.push(new OrderUndefinedError(a.getOriginalModule()));
-							compilation.errors.push(new OrderUndefinedError(b.getOriginalModule()));
+							var targetLog = options.relaxInvalidOrder ? compilation.warnings : compilation.errors;
+							targetLog.push(new OrderUndefinedError(a.getOriginalModule()));
+							targetLog.push(new OrderUndefinedError(b.getOriginalModule()));
 						}
 						return getOrder(a, b);
 					});


### PR DESCRIPTION
When migrating from a large legacy codebase to Webpack, we noticed that many of our CSS group definitions have inconsistent ordering. After trying to fix that ordering for a while, we found out that it was actually not that simple. Especially because the order might be deliberately different per entry-point and there was no way of knowing that without asking the author(s) of the respective CSS group.
The build with the `extract-text-plugin` would still generate the correct (in the sense of the definition given by the developers) output, except the CI would fail because webpack would exit with a non-zero state because of the order "errors".
Therefore we introduced an option to the plugin that allows us to degrade those errors to warnings, which makes the developers aware of their inconsistent ordering without breaking the CI build immediately.

fixes #80

cc @joscha
