### PR TITLE
fix: text.forEach is not a function

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -112,6 +112,8 @@ module.exports.pitch = function(request) {
 				var text = this.exec(source, request);
 				if(typeof text === "string")
 					text = [[0, text]];
+				if (typeof text.forEach !== "function")
+					text = [];
 				text.forEach(function(item) {
 					var id = item[0];
 					compilation.modules.forEach(function(module) {


### PR DESCRIPTION
[Fixed with code written by Cleod9](https://github.com/webpack/extract-text-webpack-plugin/issues/110#issuecomment-145687012)
