### PR TITLE
feat: add `isCacheable` option to disable loader caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ new ExtractTextPlugin(options: filename | object)
 * `options.allChunks: boolean` extract from all additional chunks too (by default it extracts only from the initial chunk(s))
 * `options.disable: boolean` disables the plugin
 * `options.id: string` Unique ident for this plugin instance. (For advanced usage only, by default automatically generated)
+* `options.ignoreOrder` defaults to `false` but for assets types where chunk order doesn't matter (local scoped CSS) you may want to set it to `true`.
 
 The `ExtractTextPlugin` generates an output file per entry, so you must use `[name]`, `[id]` or `[contenthash]` when using multiple entries.
 

--- a/index.js
+++ b/index.js
@@ -296,7 +296,7 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 			extractedChunks.forEach(function(extractedChunk) {
 				if(extractedChunk.modules.length) {
 					extractedChunk.modules.sort(function(a, b) {
-						if(isInvalidOrder(a, b)) {
+						if(options.ignoreOrder && isInvalidOrder(a, b)) {
 							compilation.errors.push(new OrderUndefinedError(a.getOriginalModule()));
 							compilation.errors.push(new OrderUndefinedError(b.getOriginalModule()));
 						}

--- a/loader.js
+++ b/loader.js
@@ -12,14 +12,25 @@ var LimitChunkCountPlugin = require("webpack/lib/optimize/LimitChunkCountPlugin"
 
 var NS = fs.realpathSync(__dirname);
 
+function isCacheableCheck(flag) {
+	if (typeof flag === "boolean") {
+		return flag;
+	}
+	// compiler-provided this.cacheable is `true` by default
+	return true;
+}
+
 module.exports = function(source) {
-	if(this.cacheable) this.cacheable();
+	var query = loaderUtils.parseQuery(this.query);
+	var isCacheable = isCacheableCheck(query.isCacheable);
+	if(this.cacheable) this.cacheable(isCacheable);
 	return source;
 };
 
 module.exports.pitch = function(request) {
-	if(this.cacheable) this.cacheable();
 	var query = loaderUtils.parseQuery(this.query);
+	var isCacheable = isCacheableCheck(query.isCacheable);
+	if(this.cacheable) this.cacheable(isCacheable);
 	this.addDependency(this.resourcePath);
 	// We already in child compiler, return empty bundle
 	if(this[NS] === undefined) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-text-webpack-plugin",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "author": "Tobias Koppers @sokra",
   "description": "Extract text from bundle into a file.",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-text-webpack-plugin",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "author": "Tobias Koppers @sokra",
   "description": "Extract text from bundle into a file.",
   "peerDependencies": {


### PR DESCRIPTION
A different approach to #87 which allows an `isCacheable` boolean option to be passed into either the ExtractTestPlugin initialization or the `extract` method.

re: #42 
