### PR TITLE
Pass proper loader `options` to children.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "async": "^1.5.0",
-    "loader-utils": "^0.2.3",
+    "loader-utils": "^0.2.16",
     "webpack-sources": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Using just the serialized request means that query objects (that is to say, those which are not strings), get munged if they have anything non-serializable in them. This means passing data to `postcss` via `query` is impossible. To remedy this, we detect when the original request is being processed and apply the original loader transformations instead of whatever came through the serialized version.

Build seems to be _only_ failing on `node@0.12` but `webpack@2` doesn't support that.. so..

See:
- https://github.com/postcss/postcss-loader/pull/104
- https://github.com/webpack-config/webpack-config-postcss/pull/10

/cc @sokra 
