### PR TITLE
allow both `loader.options` and `loader.query`, add test cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,8 +131,9 @@ module.exports = ExtractTextPlugin;
 // modified from webpack/lib/LoadersList.js
 function getLoaderWithQuery(loader) {
 	if(isString(loader)) return loader;
-	if(!loader.query) return loader.loader;
-	var query = isString(loader.query) ? loader.query : JSON.stringify(loader.query);
+	var options = loader.query || loader.options;
+	if(!options) return loader.loader;
+	var query = isString(options) ? options : JSON.stringify(options);
 	return loader.loader + "?" + query;
 }
 

--- a/test/cases/simple-options-object/a.css
+++ b/test/cases/simple-options-object/a.css
@@ -1,0 +1,3 @@
+body {
+	correct: a;
+}

--- a/test/cases/simple-options-object/b.css
+++ b/test/cases/simple-options-object/b.css
@@ -1,0 +1,3 @@
+body {
+	correct: b;
+}

--- a/test/cases/simple-options-object/expected/file.css
+++ b/test/cases/simple-options-object/expected/file.css
@@ -1,0 +1,8 @@
+body {
+	correct: a;
+}
+body {
+	correct: b;
+}
+
+/*# sourceMappingURL=file.css.map*/

--- a/test/cases/simple-options-object/index.js
+++ b/test/cases/simple-options-object/index.js
@@ -1,0 +1,2 @@
+require("./a.css");
+require("./b.css");

--- a/test/cases/simple-options-object/webpack.config.js
+++ b/test/cases/simple-options-object/webpack.config.js
@@ -1,0 +1,18 @@
+var ExtractTextPlugin = require("../../../");
+module.exports = {
+	entry: "./index",
+	module: {
+		loaders: [
+			{ test: /\.css$/, loader: ExtractTextPlugin.extract({
+				fallbackLoader: "style-loader",
+				loader: { loader: "css-loader", options: {
+					sourceMap: true
+				} }
+			}) }
+		]
+	},
+	devtool: "source-map",
+	plugins: [
+		new ExtractTextPlugin("file.css")
+	]
+};


### PR DESCRIPTION
Webpack v2 recommends using the `options` key instead of `query`: https://webpack.js.org/configuration/module/#useentry

See also: https://github.com/webpack/extract-text-webpack-plugin/commit/b79da9f375f02c349cb51cdff36ddb3c25974b69#commitcomment-19621830
