### PR TITLE
fix: usage with local classnames

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -38,7 +38,7 @@ module.exports.pitch = function(request) {
 		if(query.remove) {
 			resultSource = "// removed by extract-text-webpack-plugin";
 		} else {
-			resultSource = undefined;
+			resultSource = '';
 		}
 
 		var childFilename = "extract-text-webpack-plugin-output-filename"; // eslint-disable-line no-path-concat

--- a/test/TestCases.test.js
+++ b/test/TestCases.test.js
@@ -29,9 +29,9 @@ describe("TestCases", function() {
 			webpack(options, function(err, stats) {
 				if(err) return done(err);
 				if(stats.hasErrors()) return done(new Error(stats.toString()));
-				var testFile = path.join(outputDirectory, "test.js");
+				var testFile = path.join(testDirectory, "test.js");
 				if(fs.existsSync(testFile))
-					require(testFile)(suite);
+					require(testFile)(describe);
 				var expectedDirectory = path.join(testDirectory, "expected");
 				fs.readdirSync(expectedDirectory).forEach(function(file) {
 					var filePath = path.join(expectedDirectory, file);

--- a/test/cases/style-loader-replacement/a.css
+++ b/test/cases/style-loader-replacement/a.css
@@ -1,0 +1,7 @@
+body {
+	correct: a;
+}
+
+.a {
+	color: red;
+}

--- a/test/cases/style-loader-replacement/b.css
+++ b/test/cases/style-loader-replacement/b.css
@@ -1,0 +1,3 @@
+body {
+	correct: b;
+}

--- a/test/cases/style-loader-replacement/expected/file.css
+++ b/test/cases/style-loader-replacement/expected/file.css
@@ -1,0 +1,12 @@
+body {
+	correct: a;
+}
+
+.cssmodule--a {
+	color: red;
+}
+body {
+	correct: b;
+}
+
+/*# sourceMappingURL=file.css.map*/

--- a/test/cases/style-loader-replacement/index.js
+++ b/test/cases/style-loader-replacement/index.js
@@ -1,0 +1,3 @@
+var a = require("./a.css");
+var b = require("./b.css");
+module.exports = {a: a, b: b}

--- a/test/cases/style-loader-replacement/test.js
+++ b/test/cases/style-loader-replacement/test.js
@@ -1,0 +1,14 @@
+var fs = require('fs')
+var path = require('path')
+var should = require('should')
+var dir = path.basename(__dirname)
+
+module.exports = function (describe) {
+	describe(dir, function() {
+		it('contains compiled class names', function() {
+			var outputDirectory = path.join(__dirname, "..", "..", "js", dir);
+			var rawJS = fs.readFileSync(path.join(outputDirectory, 'main.js'), 'utf8');
+			rawJS.should.match(/\{"a":"cssmodule--a"\}/);
+		})
+	})
+}

--- a/test/cases/style-loader-replacement/webpack.config.js
+++ b/test/cases/style-loader-replacement/webpack.config.js
@@ -1,0 +1,26 @@
+var ExtractTextPlugin = require('../../../');
+module.exports = {
+	entry: "./index",
+	module: {
+		loaders: [{
+          test: /\.css$/,
+          use: ExtractTextPlugin.extract({
+			use: {
+			  loader: 'css-loader',
+			  options: {
+				// turn on CSS Modules
+				modules: true,
+				localIdentName: 'cssmodule-[path]-[name]',
+				sourceMap: true
+			  }
+			}
+		  }),
+          exclude: /node_modules/
+        }]
+	},
+	devtool: "source-map",
+	plugins: [
+		new ExtractTextPlugin({filename: 'file.css', allChunks: true})
+	]
+};
+


### PR DESCRIPTION
Prior to this, when used with css-loader and `modules: true` the compiled
class names would not get formatted properly into the JS since
`resultSource` was always `undefined`. This sets `resultSource` to an empty
string (which seems to have no detrimental effects).