### PR TITLE
Return an array of loader objects from extract()

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ function isString(a) {
 }
 
 ExtractTextPlugin.loader = function(options) {
-	return { loader: require.resolve("./loader"), query: options };
+	return { loader: require.resolve("./loader"), options: options };
 };
 
 ExtractTextPlugin.prototype.applyAdditionalInformation = function(source, info) {
@@ -179,7 +179,7 @@ ExtractTextPlugin.prototype.extract = function(options) {
 						"    fallbackLoader: string | object | loader[]\n" +
 						"    publicPath: string\n");
 	}
-	if(Array.isArray(options) || isString(options) || typeof options.query === "object") {
+	if(Array.isArray(options) || isString(options) || typeof options.options === "object" || typeof options.query === 'object') {
 		options = { loader: options };
 	}
 	var loader = options.loader;

--- a/index.js
+++ b/index.js
@@ -128,12 +128,11 @@ function ExtractTextPlugin(options) {
 }
 module.exports = ExtractTextPlugin;
 
-// modified from webpack/lib/LoadersList.js
-function getLoaderWithQuery(loader) {
-	if(isString(loader)) return loader;
-	if(!loader.query) return loader.loader;
-	var query = isString(loader.query) ? loader.query : JSON.stringify(loader.query);
-	return loader.loader + "?" + query;
+function getLoaderObject(loader) {
+	if (isString(loader)) {
+		return {loader: loader};
+	}
+	return loader;
 }
 
 function mergeOptions(a, b) {
@@ -198,8 +197,7 @@ ExtractTextPlugin.prototype.extract = function(options) {
 	delete options.fallbackLoader;
 	return [this.loader(options)]
 		.concat(before, loader)
-		.map(getLoaderWithQuery)
-		.join("!");
+		.map(getLoaderObject);
 }
 
 ExtractTextPlugin.extract = ExtractTextPlugin.prototype.extract.bind(ExtractTextPlugin);

--- a/test/extract.test.js
+++ b/test/extract.test.js
@@ -1,0 +1,144 @@
+var should = require("should");
+var ExtractTextPlugin = require("../");
+
+var loaderPath = require.resolve("../loader.js");
+
+describe("ExtractTextPlugin.extract()", function() {
+	it("throws if given multiple arguments", function() {
+		should.throws(function() {
+			ExtractTextPlugin.extract("style-loader", "css-loader");
+		});
+	});
+
+	context("specifying loader", function() {
+		it("accepts a loader string", function() {
+			ExtractTextPlugin.extract("css-loader").should.deepEqual([
+				{ loader: loaderPath, options: { omit: 0, remove:true } },
+				{ loader: "css-loader" }
+			]);
+		});
+
+		it("accepts a chained loader string", function() {
+			ExtractTextPlugin.extract(
+				"css-loader!postcss-loader!sass-loader"
+			).should.deepEqual([
+				{ loader: loaderPath, options: { omit: 0, remove:true } },
+				{ loader: "css-loader" },
+				{ loader: "postcss-loader" },
+				{ loader: "sass-loader" }
+			]);
+		});
+
+		it("accepts an array of loader names", function() {
+			ExtractTextPlugin.extract(
+				["css-loader", "postcss-loader", "sass-loader"]
+			).should.deepEqual([
+				{ loader: loaderPath, options: { omit: 0, remove:true } },
+				{ loader: "css-loader" },
+				{ loader: "postcss-loader" },
+				{ loader: "sass-loader" }
+			]);
+		});
+
+		it("accepts a loader object", function() {
+			ExtractTextPlugin.extract({ loader: "css-loader" }).should.deepEqual([
+				{ loader: loaderPath, options: { omit: 0, remove:true } },
+				{ loader: "css-loader" }
+			]);
+		});
+
+		it("accepts a loader object with an options object", function() {
+			ExtractTextPlugin.extract(
+				{ loader: "css-loader", options: { modules: true } }
+			).should.deepEqual([
+				{ loader: loaderPath, options: { omit: 0, remove:true } },
+				{ loader: "css-loader", options: { modules: true } }
+			]);
+		});
+
+		it("accepts a loader object with a (legacy) query object", function() {
+			ExtractTextPlugin.extract(
+				{ loader: "css-loader", query: { modules: true } }
+			).should.deepEqual([
+				{ loader: loaderPath, options: { omit: 0, remove:true } },
+				{ loader: "css-loader", query: { modules: true } }
+			]);
+		});
+
+		it("accepts an array of loader objects", function() {
+			ExtractTextPlugin.extract([
+				{ loader: "css-loader" },
+				{ loader: "postcss-loader" },
+				{ loader: "sass-loader" }
+			]).should.deepEqual([
+				{ loader: loaderPath, options: { omit: 0, remove:true } },
+				{ loader: "css-loader" },
+				{ loader: "postcss-loader" },
+				{ loader: "sass-loader" }
+			]);
+		});
+	})
+
+	context("specifying fallbackLoader", function() {
+		it("accepts a fallbackLoader string", function() {
+			ExtractTextPlugin.extract({
+				fallbackLoader: "style-loader",
+				loader: "css-loader"
+			}).should.deepEqual([
+				{ loader: loaderPath, options: { omit: 1, remove: true } },
+				{ loader: "style-loader" },
+				{ loader: "css-loader" }
+			]);
+		});
+
+		it("accepts a chained fallbackLoader string", function() {
+			ExtractTextPlugin.extract({
+				fallbackLoader: "something-loader!style-loader",
+				loader: "css-loader"
+			}).should.deepEqual([
+				{ loader: loaderPath, options: { omit: 2, remove: true } },
+				{ loader: "something-loader" },
+				{ loader: "style-loader" },
+				{ loader: "css-loader" }
+			]);
+		});
+
+		it("accepts a fallbackLoader object", function() {
+		 	ExtractTextPlugin.extract({
+				fallbackLoader: { loader: "style-loader" },
+				loader: "css-loader"
+			}).should.deepEqual([
+				{ loader: loaderPath, options: { omit: 1, remove: true } },
+				{ loader: "style-loader" },
+				{ loader: "css-loader" }
+			]);
+		});
+
+		it("accepts an array of fallbackLoader objects", function() {
+			ExtractTextPlugin.extract({
+				fallbackLoader: [
+					{ loader: "something-loader" },
+					{ loader: "style-loader" }
+				],
+				loader: "css-loader"
+			 }).should.deepEqual([
+				{ loader: loaderPath, options: { omit: 2, remove: true } },
+				{ loader: "something-loader" },
+				{ loader: "style-loader" },
+				{ loader: "css-loader" }
+			]);
+		});
+	});
+
+	it("passes additional options to its own loader", function() {
+		ExtractTextPlugin.extract({
+			fallbackLoader: "style-loader",
+			loader: "css-loader",
+			publicPath: "/test"
+		}).should.deepEqual([
+			{ loader: loaderPath, options: { omit: 1, remove: true, publicPath: "/test" } },
+			{ loader: "style-loader" },
+			{ loader: "css-loader" }
+		]);
+	});
+});


### PR DESCRIPTION
This allows you to `use:` the output of `extract()` by not munging everything into a string (which `use` config should obviate the need for in Webpack 2).

It's far less surprising and makes it possible to [provide plugins to preprocessor loaders directly via loader `options`](https://github.com/webpack/extract-text-webpack-plugin/issues/265#issuecomment-273773975) instead of messing around with `LoaderOptionsPlugin`

This change is as per tmair@1414036 - if @tmair wants to create their own PR for it, I'm happy to close this one.