### PR TITLE
chore(release): add standard version & documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,61 @@
+### Webpack merge, tag and release process
+
+Webpack standard Automatic versioning and CHANGELOG management, using GitHub's new squash button and
+the [recommended workflow](https://github.com/conventional-changelog/conventional-changelog-cli#recommended-workflow) for `conventional-changelog`.
+
+#### Pull requests into `master`
+
+1. When you land commits on your `master` branch, select the _Squash and Merge_ option.
+2. Add a title and body that follows the [conventional-changelog-standard conventions](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md).
+3. Land It!
+
+#### Cut a standard release
+
+```sh
+# npm run script
+npm run release
+# or global bin
+standard-version
+```
+
+_This will increment the package version based on commit history from the last tag, update the changelog accordingly, commits the changes & cuts a **local tag**_
+
+##### When satisfied with the local tag, push it up to master.
+
+```sh
+# commandline
+git push --follow-tags origin master
+```
+
+#### Cut a pre-release
+
+Use the flag `--prerelease` to generate pre-releases:
+
+_Example: Given the last version of the package is `1.0.0`, and your code to be committed has `semver: patch` level changes..._
+
+```bash
+# npm run script ( name === alpha, beta, rc )
+npm run release -- --prerelease <name>
+```
+
+_this will tag the version `1.0.1-alpha.0`_
+
+#### Cut a target release version imperatively like `npm version`
+
+To forgo the automated version bump use `--release-as` with the argument `major`, `minor` or `patch`:
+
+Suppose the last version of your code is `1.0.0`, you've only landed `fix:` commits, but
+you would like your next release to be a `minor`. Simply do:
+
+```bash
+# npm run script
+npm run release -- --release-as minor
+```
+
+_you will get version `1.1.0` rather than the auto generated version `1.0.1`._
+
+> **NOTE:** you can combine `--release-as` and `--prerelease` to generate a release. This is useful when publishing experimental feature(s).
+
+#### Signing commits and tags
+
+If you have your GPG key set up, add the `--sign` or `-s` flag to your `standard-version` command.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,15 +1,15 @@
-### Webpack merge, tag and release process
+# Webpack merge, tag and release process
 
 Webpack standard Automatic versioning and CHANGELOG management, using GitHub's new squash button and
 the [recommended workflow](https://github.com/conventional-changelog/conventional-changelog-cli#recommended-workflow) for `conventional-changelog`.
 
-#### Pull requests into `master`
+## Pull requests into `master`
 
 1. When you land commits on your `master` branch, select the _Squash and Merge_ option.
 2. Add a title and body that follows the [conventional-changelog-standard conventions](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md).
 3. Land It!
 
-#### Cut a standard release
+## Cut a standard release
 
 ```sh
 # npm run script
@@ -20,14 +20,14 @@ standard-version
 
 _This will increment the package version based on commit history from the last tag, update the changelog accordingly, commits the changes & cuts a **local tag**_
 
-##### When satisfied with the local tag, push it up to master.
+### When satisfied with the local tag, push it up to master.
 
 ```sh
 # commandline
 git push --follow-tags origin master
 ```
 
-#### Cut a pre-release
+## Cut a pre-release
 
 Use the flag `--prerelease` to generate pre-releases:
 
@@ -40,7 +40,7 @@ npm run release -- --prerelease <name>
 
 _this will tag the version `1.0.1-alpha.0`_
 
-#### Cut a target release version imperatively like `npm version`
+## Cut a target release version imperatively like `npm version`
 
 To forgo the automated version bump use `--release-as` with the argument `major`, `minor` or `patch`:
 
@@ -56,6 +56,6 @@ _you will get version `1.1.0` rather than the auto generated version `1.0.1`._
 
 > **NOTE:** you can combine `--release-as` and `--prerelease` to generate a release. This is useful when publishing experimental feature(s).
 
-#### Signing commits and tags
+## Signing commits and tags
 
 If you have your GPG key set up, add the `--sign` or `-s` flag to your `standard-version` command.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "mocha-lcov-reporter": "1.2.0",
     "raw-loader": "^0.5.1",
     "should": "^11.1.2",
+    "standard-version": "^4.0.0",
     "style-loader": "^0.13.0",
     "webpack": "^2.2.0"
   },
@@ -35,6 +36,6 @@
     "test": "mocha",
     "travis": "npm run cover -- --report lcovonly",
     "cover": "istanbul cover _mocha",
-    "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+    "release": "standard-version"
   }
 }


### PR DESCRIPTION
As discussed in webpack/webpack#4104

- Adds standard-version
- Adds documentation for generating various tags
- Adds empty changelog ( will require some `reword` work to get the full history )