### PR TITLE
fix - Implement custom `toString` for `extract`

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 var fs = require('fs');
+var querystring = require('querystring');
 var ConcatSource = require("webpack-sources").ConcatSource;
 var async = require("async");
 var ExtractedModule = require("./ExtractedModule");
@@ -202,9 +203,17 @@ ExtractTextPlugin.prototype.extract = function(options) {
 	options = mergeOptions({omit: before.length, remove: true}, options);
 	delete options.loader;
 	delete options.fallbackLoader;
-	return [this.loader(options)]
+	var result = [this.loader(options)]
 		.concat(before, loader)
 		.map(getLoaderObject);
+
+	result.toString = function() {
+		return result.map(function(o) {
+			return o.loader + '?' + querystring.stringify(o.options);
+		}).join('!');
+	};
+
+	return result;
 }
 
 ExtractTextPlugin.extract = ExtractTextPlugin.prototype.extract.bind(ExtractTextPlugin);

--- a/test/extract.test.js
+++ b/test/extract.test.js
@@ -37,133 +37,230 @@ describe("ExtractTextPlugin.extract()", function() {
 
 	context("specifying loader", function() {
 		it("accepts a loader string", function() {
-			ExtractTextPlugin.extract("css-loader").should.deepEqual([
-				{ loader: loaderPath, options: { omit: 0, remove:true } },
-				{ loader: "css-loader" }
-			]);
+			var result = ExtractTextPlugin.extract("css-loader");
+
+			delete result.toString;
+
+			should.deepEqual(
+				result,
+				[
+					{ loader: loaderPath, options: { omit: 0, remove:true } },
+					{ loader: "css-loader" }
+				]
+			);
 		});
 
 		it("accepts a chained loader string", function() {
-			ExtractTextPlugin.extract(
+			var result = ExtractTextPlugin.extract(
 				"css-loader!postcss-loader!sass-loader"
-			).should.deepEqual([
-				{ loader: loaderPath, options: { omit: 0, remove:true } },
-				{ loader: "css-loader" },
-				{ loader: "postcss-loader" },
-				{ loader: "sass-loader" }
-			]);
+			);
+
+			delete result.toString;
+
+			should.deepEqual(
+				result,
+				[
+					{ loader: loaderPath, options: { omit: 0, remove:true } },
+					{ loader: "css-loader" },
+					{ loader: "postcss-loader" },
+					{ loader: "sass-loader" }
+				]
+			);
 		});
 
 		it("accepts an array of loader names", function() {
-			ExtractTextPlugin.extract(
+			var result = ExtractTextPlugin.extract(
 				["css-loader", "postcss-loader", "sass-loader"]
-			).should.deepEqual([
-				{ loader: loaderPath, options: { omit: 0, remove:true } },
-				{ loader: "css-loader" },
-				{ loader: "postcss-loader" },
-				{ loader: "sass-loader" }
-			]);
+			);
+
+			delete result.toString;
+
+			should.deepEqual(
+				result,
+				[
+					{ loader: loaderPath, options: { omit: 0, remove:true } },
+					{ loader: "css-loader" },
+					{ loader: "postcss-loader" },
+					{ loader: "sass-loader" }
+				]
+			);
 		});
 
 		it("accepts a loader object", function() {
-			ExtractTextPlugin.extract({ loader: "css-loader" }).should.deepEqual([
-				{ loader: loaderPath, options: { omit: 0, remove:true } },
-				{ loader: "css-loader" }
-			]);
+			var result = ExtractTextPlugin.extract({ loader: "css-loader" });
+
+			delete result.toString;
+
+			should.deepEqual(
+				result,
+				[
+					{ loader: loaderPath, options: { omit: 0, remove:true } },
+					{ loader: "css-loader" }
+				]
+			);
 		});
 
 		it("accepts a loader object with an options object", function() {
-			ExtractTextPlugin.extract(
+			var result = ExtractTextPlugin.extract(
 				{ loader: "css-loader", options: { modules: true } }
-			).should.deepEqual([
-				{ loader: loaderPath, options: { omit: 0, remove:true } },
-				{ loader: "css-loader", options: { modules: true } }
-			]);
+			);
+
+			delete result.toString;
+
+			should.deepEqual(
+				result,
+				[
+					{ loader: loaderPath, options: { omit: 0, remove:true } },
+					{ loader: "css-loader", options: { modules: true } }
+				]
+			);
 		});
 
 		it("accepts a loader object with a (legacy) query object", function() {
-			ExtractTextPlugin.extract(
+			var result = ExtractTextPlugin.extract(
 				{ loader: "css-loader", query: { modules: true } }
-			).should.deepEqual([
-				{ loader: loaderPath, options: { omit: 0, remove:true } },
-				{ loader: "css-loader", query: { modules: true } }
-			]);
+			);
+
+			delete result.toString;
+
+			should.deepEqual(
+				result,
+				[
+					{ loader: loaderPath, options: { omit: 0, remove:true } },
+					{ loader: "css-loader", query: { modules: true } }
+				]
+			);
 		});
 
 		it("accepts an array of loader objects", function() {
-			ExtractTextPlugin.extract([
-				{ loader: "css-loader" },
-				{ loader: "postcss-loader" },
-				{ loader: "sass-loader" }
-			]).should.deepEqual([
-				{ loader: loaderPath, options: { omit: 0, remove:true } },
+			var result = ExtractTextPlugin.extract([
 				{ loader: "css-loader" },
 				{ loader: "postcss-loader" },
 				{ loader: "sass-loader" }
 			]);
+
+			delete result.toString;
+
+			should.deepEqual(
+				result,
+				[
+					{ loader: loaderPath, options: { omit: 0, remove:true } },
+					{ loader: "css-loader" },
+					{ loader: "postcss-loader" },
+					{ loader: "sass-loader" }
+				]
+			);
 		});
 	})
 
 	context("specifying fallbackLoader", function() {
 		it("accepts a fallbackLoader string", function() {
-			ExtractTextPlugin.extract({
+			var result = ExtractTextPlugin.extract({
 				fallbackLoader: "style-loader",
 				loader: "css-loader"
-			}).should.deepEqual([
-				{ loader: loaderPath, options: { omit: 1, remove: true } },
-				{ loader: "style-loader" },
-				{ loader: "css-loader" }
-			]);
+			});
+
+			delete result.toString;
+
+			should.deepEqual(
+				result,
+				[
+					{ loader: loaderPath, options: { omit: 1, remove: true } },
+					{ loader: "style-loader" },
+					{ loader: "css-loader" }
+				]
+			);
 		});
 
 		it("accepts a chained fallbackLoader string", function() {
-			ExtractTextPlugin.extract({
+			var result = ExtractTextPlugin.extract({
 				fallbackLoader: "something-loader!style-loader",
 				loader: "css-loader"
-			}).should.deepEqual([
-				{ loader: loaderPath, options: { omit: 2, remove: true } },
-				{ loader: "something-loader" },
-				{ loader: "style-loader" },
-				{ loader: "css-loader" }
-			]);
+			});
+
+			delete result.toString;
+
+			should.deepEqual(
+				result,
+				[
+					{ loader: loaderPath, options: { omit: 2, remove: true } },
+					{ loader: "something-loader" },
+					{ loader: "style-loader" },
+					{ loader: "css-loader" }
+				]
+			);
 		});
 
 		it("accepts a fallbackLoader object", function() {
-		 	ExtractTextPlugin.extract({
+			var result = ExtractTextPlugin.extract({
 				fallbackLoader: { loader: "style-loader" },
 				loader: "css-loader"
-			}).should.deepEqual([
-				{ loader: loaderPath, options: { omit: 1, remove: true } },
-				{ loader: "style-loader" },
-				{ loader: "css-loader" }
-			]);
+			});
+
+			delete result.toString;
+
+			should.deepEqual(
+				result,
+				[
+					{ loader: loaderPath, options: { omit: 1, remove: true } },
+					{ loader: "style-loader" },
+					{ loader: "css-loader" }
+				]
+			);
 		});
 
 		it("accepts an array of fallbackLoader objects", function() {
-			ExtractTextPlugin.extract({
+			var result = ExtractTextPlugin.extract({
 				fallbackLoader: [
 					{ loader: "something-loader" },
 					{ loader: "style-loader" }
 				],
 				loader: "css-loader"
-			 }).should.deepEqual([
-				{ loader: loaderPath, options: { omit: 2, remove: true } },
-				{ loader: "something-loader" },
-				{ loader: "style-loader" },
-				{ loader: "css-loader" }
-			]);
+			});
+
+			delete result.toString;
+
+			should.deepEqual(
+				result,
+				[
+					{ loader: loaderPath, options: { omit: 2, remove: true } },
+					{ loader: "something-loader" },
+					{ loader: "style-loader" },
+					{ loader: "css-loader" }
+				]
+			);
 		});
 	});
 
 	it("passes additional options to its own loader", function() {
-		ExtractTextPlugin.extract({
+		var result = ExtractTextPlugin.extract({
 			fallbackLoader: "style-loader",
 			loader: "css-loader",
 			publicPath: "/test"
-		}).should.deepEqual([
-			{ loader: loaderPath, options: { omit: 1, remove: true, publicPath: "/test" } },
-			{ loader: "style-loader" },
-			{ loader: "css-loader" }
-		]);
+		});
+
+		delete result.toString;
+
+		should.deepEqual(
+			result,
+			[
+				{ loader: loaderPath, options: { omit: 1, remove: true, publicPath: "/test" } },
+				{ loader: "style-loader" },
+				{ loader: "css-loader" }
+			]
+		);
+	});
+
+	it("implements custom toString", function() {
+		var result = ExtractTextPlugin.extract({
+			fallbackLoader: "style-loader",
+			loader: "css-loader",
+			publicPath: "/test"
+		});
+
+		should.equal(
+			result.toString(),
+			process.cwd() + '/loader.js?omit=1&remove=true&publicPath=%2Ftest!style-loader?!css-loader?'
+		);
 	});
 });


### PR DESCRIPTION
This should fix the behavior with loaders that rely on pitching. Since it needs to deal with a string, `extract` should return the loader in a query format as well.

The change allows the `extract` to be used with `loader` field again.

There's one gotcha - the current solution doesn't handle functions (postcss) in any special way. That may require further thinking.

Closes #364.
Closes #370.