### PR TITLE
docs - adds array type for options.use and options.fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Creates an extracting loader from an existing loader. Supports loaders of type `
 
 |Name|Type|Description|
 |:--:|:--:|:----------|
-|**`options.use`**|`{String}`/`{Object}`|Loader(s) that should be used for converting the resource to a CSS exporting module _(required)_|
-|**`options.fallback`**|`{String}`/`{Object}`|loader(e.g `'style-loader'`) that should be used when the CSS is not extracted (i.e. in an additional chunk when `allChunks: false`)|
+|**`options.use`**|`{String}`/`{Array}`/`{Object}`|Loader(s) that should be used for converting the resource to a CSS exporting module _(required)_|
+|**`options.fallback`**|`{String}`/`{Array}`/`{Object}`|loader(e.g `'style-loader'`) that should be used when the CSS is not extracted (i.e. in an additional chunk when `allChunks: false`)|
 |**`options.publicPath`**|`{String}`|Override the `publicPath` setting for this loader|
 
 


### PR DESCRIPTION
Noticed that documentation is outdated for the `options.use` and the `options.fallback` types. As far as I can tell, they should also be able to be an array (especially since they are replacing the `fallbackLoader` and the `loader` options and they were able to be arrays): https://github.com/webpack-contrib/extract-text-webpack-plugin/blob/master/schema/loader-schema.js