### PR TITLE
fix: add a not null check for the content property before throwing error

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 									return callback();
 								}
 								meta = module[NS];
-								if(!Array.isArray(meta.content) && meta.context != null) {
+								if(!Array.isArray(meta.content) && meta.content != null) {
 									err = new Error(module.identifier() + " doesn't export content");
 									compilation.errors.push(err);
 									return callback();

--- a/index.js
+++ b/index.js
@@ -269,6 +269,7 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 									return callback();
 								}
 								meta = module[NS];
+								// Error out if content is not an array and is not null
 								if(!Array.isArray(meta.content) && meta.content != null) {
 									err = new Error(module.identifier() + " doesn't export content");
 									compilation.errors.push(err);

--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 									return callback();
 								}
 								meta = module[NS];
-								if(!Array.isArray(meta.content)) {
+								if(!Array.isArray(meta.content) && meta.context != null) {
 									err = new Error(module.identifier() + " doesn't export content");
 									compilation.errors.push(err);
 									return callback();


### PR DESCRIPTION
This check will fix #42 for webpack2 users.
