### PR TITLE
beta version warning and css-loader options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ npm install --save-dev extract-text-webpack-plugin
 
 > :warning: For webpack v1, see [the README in the webpack-1 branch](https://github.com/webpack/extract-text-webpack-plugin/blob/webpack-1/README.md).
 
+> :warning: The following example code only works with the beta version.
+
 ```js
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 
@@ -36,6 +38,29 @@ module.exports = {
         use: ExtractTextPlugin.extract({
           fallback: "style-loader",
           use: "css-loader"
+        })
+      }
+    ]
+  },
+  plugins: [
+    new ExtractTextPlugin("styles.css"),
+  ]
+}
+```
+
+If you need to use options with `css-loader`.
+
+```js
+const ExtractTextPlugin = require("extract-text-webpack-plugin");
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: ExtractTextPlugin.extract({
+          fallback: "style-loader",
+          use: 'css-loader?modules,localIdentName="[name]-[local]-[hash:base64:6]"'
         })
       }
     ]


### PR DESCRIPTION
Added beta-version code example warning and using options with css-loader to support css-modules

1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
4. Remove these instructions from your PR as they are for your eyes only.
