### PR TITLE
Make documentation regarding extracting Sass/LESS clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,36 @@ module.exports = {
 };
 ```
 
+### Extracting Sass or LESS
+
+The configuration is the same, switch out `sass-loader` for `less-loader` when necessary.
+
+```js
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+module.exports = {
+  module: {
+    use: [
+      {
+        test: /\.scss$/,
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          //resolve-url-loader may be chained before sass-loader if necessary
+          use: ['css-loader', 'sass-loader']
+        })
+      }
+    ]
+  },
+  plugins: [
+    new ExtractTextPlugin('style'css)
+    //if you want to pass in options, you can do so:
+    //new ExtractTextPlugin({
+    //  filename: 'style.css'
+    //})
+  ]
+}
+```
+
 <h2 align="center">Maintainer</h2>
 
 <table>

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ module.exports = {
     ]
   },
   plugins: [
-    new ExtractTextPlugin('style'css)
+    new ExtractTextPlugin('style.css')
     //if you want to pass in options, you can do so:
     //new ExtractTextPlugin({
     //  filename: 'style.css'


### PR DESCRIPTION
There's been a lot of issues regarding extracting Sass/LESS. I hope this readme will make things easier for others.

This worked for me on `Node 7.5.0` and `webpack@2.2.1`. I can provide an example repo.
