### PR TITLE
Fix table layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ new ExtractTextPlugin(options: filename | object)
 |Name|Type|Description|
 |:--:|:--:|:----------|
 |**`id`**|`{String}`|Unique ident for this plugin instance. (For advanced usage only, by default automatically generated)|
-|**`filename`**|`{String\|Function}`|Name of the result file. May contain `[name]`, `[id]` and `[contenthash]`|
+|**`filename`**|`{String/Function}`|Name of the result file. May contain `[name]`, `[id]` and `[contenthash]`|
 |**`allChunks`**|`{Boolean}`|Extract from all additional chunks too (by default it extracts only from the initial chunk(s))<br />When using `CommonsChunkPlugin` and there are extracted chunks (from `ExtractTextPlugin.extract`) in the commons chunk, `allChunks` **must** be set to `true`|
 |**`disable`**|`{Boolean}`|Disables the plugin|
 |**`ignoreOrder`**|`{Boolean}`|Disables order check (useful for CSS Modules!), `false` by default|


### PR DESCRIPTION
A misplaced `|` was breaking the row.