### PR TITLE
docs(README): add lead-in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
       src="https://webpack.js.org/assets/icon-square-big.svg">
   </a>
   <h1>Extract Text Plugin</h1>
+  <p>Extract text from a bundle, or bundles, into a separate file.</p>
 </div>
 
 <h2 align="center">Install</h2>


### PR DESCRIPTION
See webpack/webpack.js.org#1161 and [this page](https://webpack.js.org/plugins/extract-text-webpack-plugin/) in the docs which lacks a good lead-in sentence.