### PR TITLE
Add ignoreOrder check

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,7 +289,7 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 			extractedChunks.forEach(function(extractedChunk) {
 				if(extractedChunk.modules.length) {
 					extractedChunk.modules.sort(function(a, b) {
-						if(isInvalidOrder(a, b)) {
+						if(!options.ignoreOrder && isInvalidOrder(a, b)) {
 							compilation.errors.push(new OrderUndefinedError(a.getOriginalModule()));
 							compilation.errors.push(new OrderUndefinedError(b.getOriginalModule()));
 						}


### PR DESCRIPTION
This PR adds the ignoreOrder checks added by #166 in the master branch. I realize the optimum solution for this issue is to migrate to Webpack 2 but since I'd consider this issue fairly debilitating, I think a fix should be present for those who need something in their production environments right away and can't go through the steps to migrate.
