### PR TITLE
docs(README): use warning emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ new ExtractTextPlugin(options: filename | object)
 * `[id]` number of the chunk
 * `[contenthash]` hash of the content of the extracted file
 
-> :warning: `ExtractTextPlugin` generates a file **per entry**, so you must use `[name]`, `[id]` or `[contenthash]` when using multiple entries.
+> ⚠ `ExtractTextPlugin` generates a file **per entry**, so you must use `[name]`, `[id]` or `[contenthash]` when using multiple entries.
 
 #### `#extract`
 


### PR DESCRIPTION
Fixes display of `:warning:` on https://webpack.js.org/plugins/extract-text-webpack-plugin/#usage