### PR TITLE
fix: add missing `options.ignoreOrder` details in Error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,8 @@ function ExtractTextPlugin(options) {
 						"The available options are:\n" +
 						"    filename: string\n" +
 						"    allChunks: boolean\n" +
-						"    disable: boolean\n");
+						"    disable: boolean\n" +
+						"    ignoreOrder: boolean\n");
 	}
 	if(isString(options)) {
 		options = { filename: options };
@@ -337,7 +338,7 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 					});
 
 					var file = (isFunction(filename)) ? filename(getPath) : getPath(filename);
-					
+
 					compilation.assets[file] = source;
 					chunk.files.push(file);
 				}


### PR DESCRIPTION
https://github.com/webpack-contrib/extract-text-webpack-plugin/pull/520 Adds an option: "ignoreOrder" this is not listed in the available options in the error output for this plugin. Which can be confusing. 