### PR TITLE
refactor: `Chunk.modules` => `Chunk.mapModules`  (`webpack v3.0.0`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var Chunk = require("webpack/lib/Chunk");
 var OrderUndefinedError = require("./OrderUndefinedError");
 var loaderUtils = require("loader-utils");
 var validateOptions = require('schema-utils');
+var path = require('path');
 
 var NS = fs.realpathSync(__dirname);
 
@@ -124,7 +125,7 @@ function ExtractTextPlugin(options) {
 	if(isString(options)) {
 		options = { filename: options };
 	} else {
-		validateOptions('./schema/plugin.json', options, 'Extract Text Plugin');
+		validateOptions(path.resolve(__dirname, './schema/plugin.json'), options, 'Extract Text Plugin');
 	}
 	this.filename = options.filename;
 	this.id = options.id != null ? options.id : ++nextId;
@@ -203,7 +204,7 @@ ExtractTextPlugin.prototype.extract = function(options) {
 	if(Array.isArray(options) || isString(options) || typeof options.options === "object" || typeof options.query === 'object') {
 		options = { loader: options };
 	} else {
-		validateOptions('./schema/loader.json', options, 'Extract Text Plugin (Loader)');
+		validateOptions(path.resolve(__dirname, './schema/loader.json'), options, 'Extract Text Plugin (Loader)');
 	}
 	var loader = options.use ||  options.loader;
 	var before = options.fallback || options.fallbackLoader || [];

--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 			async.forEach(chunks, function(chunk, callback) {
 				var extractedChunk = extractedChunks[chunks.indexOf(chunk)];
 				var shouldExtract = !!(options.allChunks || isInitialOrHasNoParents(chunk));
-				async.forEach(chunk.modules.slice(), function(module, callback) {
+				async.forEach(chunk.mapModules(function(c) { return c; }), function(module, callback) {
 					var meta = module[NS];
 					if(meta && (!meta.options.id || meta.options.id === id)) {
 						var wasExtracted = Array.isArray(meta.content);


### PR DESCRIPTION
Refactors to use webpack 3.x `Chunk.mapModules` 

Closes #529 

> Squashed commit message body for merge
```

- refactor: DeprecationWarning: Chunk.modules

BREAKING CHANGE: Updates to `Chunk.mapModules`. This release is not backwards compatible with `Webpack 2.x` due to breaking changes in webpack/webpack#4764
```