### PR TITLE
refactor: Update deprecated `chunk.modules` functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "node": ">= 4.3 < 5.0.0 || >= 5.10"
   },
   "peerDependencies": {
-    "webpack": "^3.0.0"
+    "webpack": "^3.1.0"
   },
   "homepage": "http://github.com/webpack-contrib/extract-text-webpack-plugin",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -144,6 +144,7 @@ class ExtractTextPlugin {
         async.forEach(chunks, (chunk, callback) => { // eslint-disable-line no-shadow
           const extractedChunk = extractedChunks[chunks.indexOf(chunk)];
           const shouldExtract = !!(options.allChunks || isInitialOrHasNoParents(chunk));
+          chunk.sortModules();
           async.forEach(chunk.mapModules((c) => { return c; }), (module, callback) => { // eslint-disable-line no-shadow, arrow-body-style
             let meta = module[NS];
             if (meta && (!meta.options.id || meta.options.id === id)) {

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ class ExtractTextPlugin {
       }, this);
     } else if (checkedChunks.indexOf(chunk) < 0) {
       checkedChunks.push(chunk);
-      chunk.modules.slice().forEach((module) => {
+      chunk.forEachModule((module) => {
         intoChunk.addModule(module);
         module.addChunk(intoChunk);
       });
@@ -77,7 +77,7 @@ class ExtractTextPlugin {
 
   renderExtractedChunk(chunk) {
     const source = new ConcatSource();
-    chunk.modules.forEach((module) => {
+    chunk.forEachModule((module) => {
       const moduleSource = module.source();
       source.add(this.applyAdditionalInformation(moduleSource, module.additionalInformation));
     }, this);
@@ -145,7 +145,7 @@ class ExtractTextPlugin {
           const extractedChunk = extractedChunks[chunks.indexOf(chunk)];
           const shouldExtract = !!(options.allChunks || isInitialOrHasNoParents(chunk));
           chunk.sortModules();
-          async.forEach(chunk.mapModules((c) => { return c; }), (module, callback) => { // eslint-disable-line no-shadow, arrow-body-style
+          async.forEach(chunk.mapModules(c => c), (module, callback) => { // eslint-disable-line no-shadow
             let meta = module[NS];
             if (meta && (!meta.options.id || meta.options.id === id)) {
               const wasExtracted = Array.isArray(meta.content);
@@ -182,7 +182,7 @@ class ExtractTextPlugin {
           }, this);
           extractedChunks.forEach((extractedChunk) => {
             if (!isInitialOrHasNoParents(extractedChunk)) {
-              extractedChunk.modules.slice().forEach((module) => {
+              extractedChunk.forEachModule((module) => {
                 extractedChunk.removeModule(module);
               });
             }
@@ -193,7 +193,7 @@ class ExtractTextPlugin {
       });
       compilation.plugin('additional-assets', (callback) => {
         extractedChunks.forEach((extractedChunk) => {
-          if (extractedChunk.modules.length) {
+          if (extractedChunk.getNumberOfModules()) {
             extractedChunk.modules.sort((a, b) => {
               if (!options.ignoreOrder && isInvalidOrder(a, b)) {
                 compilation.errors.push(new OrderUndefinedError(a.getOriginalModule()));

--- a/test/cases/chunk-modules-ordered-by-id/a.js
+++ b/test/cases/chunk-modules-ordered-by-id/a.js
@@ -1,0 +1,1 @@
+require('./c.txt');

--- a/test/cases/chunk-modules-ordered-by-id/b.txt
+++ b/test/cases/chunk-modules-ordered-by-id/b.txt
@@ -1,0 +1,3 @@
+.block {
+	color: tomato;
+}

--- a/test/cases/chunk-modules-ordered-by-id/c.txt
+++ b/test/cases/chunk-modules-ordered-by-id/c.txt
@@ -1,0 +1,3 @@
+.App {
+	color: black;
+}

--- a/test/cases/chunk-modules-ordered-by-id/expected/file.css
+++ b/test/cases/chunk-modules-ordered-by-id/expected/file.css
@@ -1,0 +1,6 @@
+.block {
+	color: tomato;
+}
+.App {
+	color: black;
+}

--- a/test/cases/chunk-modules-ordered-by-id/index.js
+++ b/test/cases/chunk-modules-ordered-by-id/index.js
@@ -1,0 +1,2 @@
+require('./a');
+require('./b.txt');

--- a/test/cases/chunk-modules-ordered-by-id/webpack.config.js
+++ b/test/cases/chunk-modules-ordered-by-id/webpack.config.js
@@ -1,0 +1,7 @@
+var ExtractTextPlugin = require("../../../");
+module.exports = {
+	entry: "./index",
+	plugins: [
+		new ExtractTextPlugin("file.css")
+	]
+};


### PR DESCRIPTION
Replaces remaining usage of the deprecated `chunk.modules` functions

- [x] refactor: Replace usage of chunk.modules

  BREAKING CHANGE: Updates to `Chunk.mapModules | forEachModule | getNumberOfModules`. This release is not backwards compatible with `Webpack 2.x` due to breaking changes in webpack/webpack#4764

Closes #548