### PR TITLE
Add webpack 3.0 to acceptable peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "OrderUndefinedError.js"
   ],
   "peerDependencies": {
-    "webpack": "^2.2.0"
+    "webpack": "^2.2.0 || ^3.0.0"
   },
   "dependencies": {
     "schema-utils": "^0.3.0",


### PR DESCRIPTION
I'm currently getting peer dependency warnings about this package when trying to use Webpack 3.0.
```
warning "extract-text-webpack-plugin@2.1.2" has incorrect peer dependency "webpack@^2.2.0".
```

Everything appears to be working as expected, so it should be safe to add 3.0 to the acceptable peerDependencies.