### PR TITLE
fix(index): CSS module sorting (`extractedChunk.sortModules(cb)`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,6 +144,7 @@ class ExtractTextPlugin {
         async.forEach(chunks, (chunk, callback) => { // eslint-disable-line no-shadow
           const extractedChunk = extractedChunks[chunks.indexOf(chunk)];
           const shouldExtract = !!(options.allChunks || isInitialOrHasNoParents(chunk));
+          chunk.sortModules(module);
           async.forEach(chunk.mapModules(c => c), (module, callback) => { // eslint-disable-line no-shadow
             let meta = module[NS];
             if (meta && (!meta.options.id || meta.options.id === id)) {

--- a/test/__snapshots__/webpack-integration.test.js.snap
+++ b/test/__snapshots__/webpack-integration.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`Webpack Integration Tests chunk-modules-css-wrong-order 1`] = `
 ".block {
-  font-size: 16px;
+	color: tomato;
 }
 .App {
-  text-align: center;
+	color: black;
 }
 "
 `;


### PR DESCRIPTION
### Before
![modules_sort](https://user-images.githubusercontent.com/5419992/27963829-786c3c0c-6336-11e7-87fd-6e3d7388ffa8.png)

### After
![sortmodules](https://user-images.githubusercontent.com/5419992/27963840-7f23efcc-6336-11e7-8092-d195ab56cf09.png)
