### PR TITLE
docs(README): add custom `[contenthash]` formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ new ExtractTextPlugin(options: filename | object)
 * `[name]` name of the chunk
 * `[id]` number of the chunk
 * `[contenthash]` hash of the content of the extracted file
+* `[<hashType>:contenthash:<digestType>:<length>]` optionally you can configure
+  * other `hashType`s, e.g. `sha1`, `md5`, `sha256`, `sha512`
+  * other `digestType`s, e.g. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
+  * and `length`, the length of the hash in chars
 
 > :warning: `ExtractTextPlugin` generates a file **per entry**, so you must use `[name]`, `[id]` or `[contenthash]` when using multiple entries.
 


### PR DESCRIPTION
In README, document the ability to use `[<hashType>:contenthash:<digestType>:<length>]` in filenames. This feature is similarly documented in the README of [hash-loader](https://github.com/webpack-contrib/file-loader/blob/master/README.md).