### PR TITLE
fix: Modules shouldn't be passed to sort

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,7 @@ class ExtractTextPlugin {
         async.forEach(chunks, (chunk, callback) => { // eslint-disable-line no-shadow
           const extractedChunk = extractedChunks[chunks.indexOf(chunk)];
           const shouldExtract = !!(options.allChunks || isInitialOrHasNoParents(chunk));
-          chunk.sortModules(module);
+          chunk.sortModules();
           async.forEach(chunk.mapModules(c => c), (module, callback) => { // eslint-disable-line no-shadow
             let meta = module[NS];
             if (meta && (!meta.options.id || meta.options.id === id)) {


### PR DESCRIPTION
- module was incorrectly being passed to the sort function with throws a type error in certain circumstances.

Fixes #565
Fixes #554