### PR TITLE
fix: get realpath from `__filename` instead of `__dirname` (`NS`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import {
   isFunction,
 } from './lib/helpers';
 
-const NS = fs.realpathSync(__dirname);
+const NS = path.dirname(fs.realpathSync(__filename));
 
 let nextId = 0;
 

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import loaderUtils from 'loader-utils';
 import NodeTemplatePlugin from 'webpack/lib/node/NodeTemplatePlugin';
 import NodeTargetPlugin from 'webpack/lib/node/NodeTargetPlugin';
@@ -6,7 +7,7 @@ import LibraryTemplatePlugin from 'webpack/lib/LibraryTemplatePlugin';
 import SingleEntryPlugin from 'webpack/lib/SingleEntryPlugin';
 import LimitChunkCountPlugin from 'webpack/lib/optimize/LimitChunkCountPlugin';
 
-const NS = fs.realpathSync(__dirname);
+const NS = path.dirname(fs.realpathSync(__filename));
 
 export default source => source;
 


### PR DESCRIPTION
Without this fix, this plugin doesn't work if your node_modules tree is
made up of real directories, but your files are symlinks. It's admittedly a
weird environment, but that's the environment that the Bazel build
system runs code in, which is the build system we use at Dropbox.

This is the bug:

 - index.js is called from the runfiles directory, and it uses the
   realpath of its directory as the key for a function on the
   loaderContext object.

 - loader.js is called from the bazel-bin/npm directory outside
   of its runfiles (because Webpack escapes the runfiles when it
   calls loaders). It uses the realpath of its directory as a
   key on the loaderContext object, but because it's in a
   different directory from index.js, it can't find the function
   set on the loaderContext by index.js.

The fix is to get the realpath of the filename instead of the
directory so that both files point to the same place.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
