### PR TITLE
fix(loader/pitch): unnecessary addition of redundant `fileDependencies` (`this.addDependency`)

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -14,7 +14,6 @@ export default source => source;
 export function pitch(request) {
   const query = loaderUtils.getOptions(this) || {};
   let loaders = this.loaders.slice(this.loaderIndex + 1);
-  this.addDependency(this.resourcePath);
   // We already in child compiler, return empty bundle
   if (this[NS] === undefined) { // eslint-disable-line no-undefined
     throw new Error(


### PR DESCRIPTION
### `Problem`
I've found the [commit][1] where it was introduced. My conjecture is that `webpack` didn't add this dependency itself back then. Or this line was added just in case.

[1]: https://github.com/webpack-contrib/extract-text-webpack-plugin/commit/f7d5bbf1c4eb3fab60c7656aece076d3d5c06912

### `Questions`

If I've got to back it with tests, then I might need your help. My idea is to add a couple of tests to [`test/webpack-integration.test.js`][2], since putting it into `test/cases` doesn't seem like an option. Tests from the latter dir expect on the files output by `webpack`. With dependencies you've got to hook into compilation process. Supposedly how I did in the issue. That would probably be the best way.

Also, can you explain what dependency adds [this line][3] to save me some time? Between what and what exactly?

[3]: https://github.com/webpack-contrib/extract-text-webpack-plugin/blob/v3.0.1/src/loader.js#L88

[2]: https://github.com/webpack-contrib/extract-text-webpack-plugin/blob/v3.0.1/test/webpack-integration.test.js

### `Issues`

- Fixes #632

> ℹ️  edited by @michael-ciniawsky (Formatting)