### PR TITLE
refactor(loader): export `locals` as ES2015 module

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -107,7 +107,7 @@ export function pitch(request) {
         }
         this[NS](text, query);
         if (text.locals && typeof resultSource !== 'undefined') {
-          resultSource += `\nmodule.exports = ${JSON.stringify(text.locals)};`;
+          resultSource += `\nexport default ${JSON.stringify(text.locals)};`;
         }
       } catch (e) {
         return callback(e);


### PR DESCRIPTION
### `Noteable Changes`

This pull request replaces `module.exports` with `export default` to allow `webpack` to take advantage of ES2015 module to reduce creating a scope for each stylesheet imported. It also solves #229 when ModuleConcatenationPlugin is turned on.

### `Needs Triage`

1. If you use CSS Module with a wildcard `import * as style from './style.css'` (which I don’t think was supported in the first place), it will stop working until `* as` is removed.
2. ~~Will this break for CommonJS users?~~ Yes.

### `Issues`

- Fixes #229