### PR TITLE
fix: "Cannot read property 'initial' of undefined" (#202) (`webpack =< 1.0.0`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ ExtractTextPlugin.prototype.mergeNonInitialChunks = function(chunk, intoChunk, c
 	if(!intoChunk) {
 		checkedChunks = [];
 		chunk.chunks.forEach(function(c) {
-			if(c.initial) return;
+			if(!c || c.initial) return;
 			this.mergeNonInitialChunks(c, chunk, checkedChunks);
 		}, this);
 	} else if(checkedChunks.indexOf(chunk) < 0) {
@@ -29,7 +29,7 @@ ExtractTextPlugin.prototype.mergeNonInitialChunks = function(chunk, intoChunk, c
 			module.addChunk(intoChunk);
 		});
 		chunk.chunks.forEach(function(c) {
-			if(c.initial) return;
+			if(!c || c.initial) return;
 			this.mergeNonInitialChunks(c, intoChunk, checkedChunks);
 		}, this);
 	}


### PR DESCRIPTION
copied from https://github.com/webpack-contrib/extract-text-webpack-plugin/pull/202/files

this fix the issue for webpack 1 projects
