### PR TITLE
docs(README): add example how-to disable `url()` resolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,20 @@ module.exports = {
         test: /\.scss$/,
         use: ExtractTextPlugin.extract({
           fallback: 'style-loader',
-          //resolve-url-loader may be chained before sass-loader if necessary
-          use: ['css-loader', 'sass-loader']
+          use: [{
+              loader: 'css-loader',
+              options: {
+                  url: false, // If you are having trouble with urls not resolving add this setting.
+                  minimize: true,
+                  sourceMap: true
+              }
+          }, 
+          {
+              loader: 'sass-loader',
+              options: {
+                  sourceMap: true
+              }
+          }]
         })
       }
     ]

--- a/README.md
+++ b/README.md
@@ -146,20 +146,7 @@ module.exports = {
         test: /\.scss$/,
         use: ExtractTextPlugin.extract({
           fallback: 'style-loader',
-          use: [{
-              loader: 'css-loader',
-              options: {
-                  url: false, // If you are having trouble with urls not resolving add this setting.
-                  minimize: true,
-                  sourceMap: true
-              }
-          }, 
-          {
-              loader: 'sass-loader',
-              options: {
-                  sourceMap: true
-              }
-          }]
+          use: ['css-loader', 'sass-loader']
         })
       }
     ]
@@ -171,6 +158,45 @@ module.exports = {
     //  filename: 'style.css'
     //})
   ]
+}
+```
+
+### `url()` Resolving
+
+If you are finding that urls are not resolving properly when you run webpack. You can expand your loader functionality with options. The `url: false` property allows your paths resolved without any changes.
+
+```js
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.scss$/,
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: [
+            {
+                loader: 'css-loader',
+                options: {
+                    // If you are having trouble with urls not resolving add this setting.
+                    // See https://github.com/webpack-contrib/css-loader#url
+                    url: false,
+                    minimize: true,
+                    sourceMap: true
+                }
+            }, 
+            {
+                loader: 'sass-loader',
+                options: {
+                    sourceMap: true
+                }
+            }
+          ]
+        })
+      }
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
I was scouring the internet looking for how to get my css url() to resolve when webpack compiles. I couldn't find anything! But, I took a guess at setting `url: false` in the options for my loader and it worked! It would be beneficial to have this documentation on the readme. Thanks for the awesome plugin!

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
