### PR TITLE
refactor(loader): do not throw errors in case of child context

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -16,12 +16,11 @@ export function pitch(request) {
   let loaders = this.loaders.slice(this.loaderIndex + 1);
   this.addDependency(this.resourcePath);
   // We already in child compiler, return empty bundle
-  if (this[NS] === undefined) { // eslint-disable-line no-undefined
-    throw new Error(
+  if (this[NS] === undefined || this[NS] === false) { // eslint-disable-line no-undefined
+    this.emitWarning(
       '"extract-text-webpack-plugin" loader is used without the corresponding plugin, ' +
       'refer to https://github.com/webpack/extract-text-webpack-plugin for the usage example',
     );
-  } else if (this[NS] === false) {
     return '';
   } else if (this[NS](null, query)) {
     if (query.omit) {


### PR DESCRIPTION
I'm resubmitting the PR on behalf of the original contributor #390. They originally were asked to do it after #540 hit master which it has. The original contributor hasn't submitted the PR but I'd like to be using the master version of extract-text-plugin with the patch.

This basically changes the error on child context to a warning. The use case is when using extract-text-plugin with html-webpack-plugin to pull css into its own file at compilation time, same as the original #390. I've applied the same commit on master and been using it in my own fork since it hasn't been merged yet.
