### PR TITLE
fix(loader): change comment type

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -31,7 +31,7 @@ export function pitch(request) {
     }
     let resultSource;
     if (query.remove) {
-      resultSource = '// removed by extract-text-webpack-plugin';
+      resultSource = '/* removed by extract-text-webpack-plugin */';
     } else {
       resultSource = undefined; // eslint-disable-line no-undefined
     }


### PR DESCRIPTION
Double slash (//) comment causes problems with other css loaders.
Instance is used /**/ that's fully compatible

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
