### PR TITLE
Ensure that some loader options are integers

### DIFF
--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -54,3 +54,8 @@ export function isFunction(a) {
 export function isType(type, obj) {
   return Object.prototype.toString.call(obj) === `[object ${type}]`;
 }
+
+export function ensureNumber(value) {
+  const newValue = Number(value);
+  return Number.isNaN(newValue) ? value : newValue;
+}

--- a/src/loader.js
+++ b/src/loader.js
@@ -6,6 +6,7 @@ import NodeTargetPlugin from 'webpack/lib/node/NodeTargetPlugin';
 import LibraryTemplatePlugin from 'webpack/lib/LibraryTemplatePlugin';
 import SingleEntryPlugin from 'webpack/lib/SingleEntryPlugin';
 import LimitChunkCountPlugin from 'webpack/lib/optimize/LimitChunkCountPlugin';
+import { ensureNumber } from './lib/helpers';
 
 const NS = path.dirname(fs.realpathSync(__filename));
 
@@ -13,6 +14,9 @@ export default source => source;
 
 export function pitch(request) {
   const query = loaderUtils.getOptions(this) || {};
+  query.id = ensureNumber(query.id);
+  query.omit = ensureNumber(query.omit);
+
   let loaders = this.loaders.slice(this.loaderIndex + 1);
   this.addDependency(this.resourcePath);
   // We already in child compiler, return empty bundle


### PR DESCRIPTION
If the string syntax is used to define the loader, like:

```
extract-text-plugin/loader?id=1omit=1&remove=true!style-loader!postcss-loader
```

Then the resulting query object in the loader looks like:

```
{ id: '1', omit: '1' }
```

While it should be:

```
{ id: 1, omit: 1 }
```

If the ID is a string, then the loader won't find the ExtractTextPlugin
instance to report the extracted text to, therefor, no text would
be extracted.

This fixes issue #752 

I am not entirely sure the fix is correct, but it works when wrapping the loader in `multi(combineLoaders(..))`, which both use the string syntax.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
