### PR TITLE
fix: missing options property in schema and ID's should be strings

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -2,6 +2,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "id": {
+      "description": "Unique ident for this plugin instance. (For advanced usage only, by default automatically generated).",
+      "type": "string"
+    },
     "allChunks": {
       "description": "",
       "type": "boolean"

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ class ExtractTextPlugin {
       validateOptions(path.resolve(__dirname, '../schema/plugin.json'), options, 'Extract Text Plugin');
     }
     this.filename = options.filename;
-    this.id = options.id != null ? options.id : ++nextId;
+    this.id = String(options.id != null ? options.id : ++nextId);
     this.options = {};
     mergeOptions(this.options, options);
     delete this.options.filename;


### PR DESCRIPTION
An explanation for this in detail: https://github.com/webpack-contrib/multi-loader/issues/10#issuecomment-379463986

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
