### PR TITLE
docs(readme) WP4 deprecation for css. Link to MiniCSSExtractPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install --save-dev extract-text-webpack-plugin@1.0.1
 
 <h2 align="center">Usage</h2>
 
-> :warning: The extract-text-webpack-plugin has been removed in webpack v4 legato. Please use [mini-css-extract-plugin](https://github.com/webpack-contrib/mini-css-extract-plugin) instead.
+> :warning: Since webpack v4 the `extract-text-webpack-plugin` should not be used for css. Use [mini-css-extract-plugin](https://github.com/webpack-contrib/mini-css-extract-plugin) instead.
 
 > :warning: For webpack v1, see [the README in the webpack-1 branch](https://github.com/webpack/extract-text-webpack-plugin/blob/webpack-1/README.md).
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ npm install --save-dev extract-text-webpack-plugin@1.0.1
 
 <h2 align="center">Usage</h2>
 
+> :warning: The extract-text-webpack-plugin has been removed in webpack v4 legato. Please use [mini-css-extract-plugin](https://github.com/webpack-contrib/mini-css-extract-plugin) instead.
+
 > :warning: For webpack v1, see [the README in the webpack-1 branch](https://github.com/webpack/extract-text-webpack-plugin/blob/webpack-1/README.md).
 
 ```js


### PR DESCRIPTION
* mention deprecation of ETWP for css usage for webpack v4+
* link to `mini-css-extract-plugin`

Fixes webpack/webpack.js.org#2001