### PR TITLE
fix(package): remove `webpack =< v3.0.0` (`peerDependencies`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "webpack"
   ],
   "peerDependencies": {
-    "webpack": "^3.0.0 || ^4.0.0"
+    "webpack": "^4.0.0"
   },
   "dependencies": {
     "async": "^2.4.1",


### PR DESCRIPTION
We should remove webpack@3.0.0 as a "peerDependencies" to this version of extract-text-webpack-plugin.

### problem

extract-text-webpack@next (4.0.0-beta.0) is not compatible with webpack 3.x. I am assuming this is the direction you are going with this plugin (correct me if I am wrong). For example, this is the incompatibility line I faced that is problematic if `webpack@3.x` is used:

https://github.com/webpack-contrib/extract-text-webpack-plugin/blob/34e508342df9c4fb3fb2a3ddef4700c5a58f9fb0/src/index.js#L222

### why we need this change
Let's assume you have an application that uses `webpack@3.x` and a packages `A` that uses `webpack@4.x` and `extract-text-webpack@next`. When installing the dependencies, `extract-text-webpack` gets installed in the root `node_modules` not `node_modules/A/node_modules`. This obviously forces `extract-text-webpack` to load `webpack@3.x` from the root and breaks the build in package `A` :(

I can provide an example application to demonstrate that behaviour, though it is cumbersome to prove this point, especially if there is no plan to support `webpack@3.x` in `extract-text-webpack@next`.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
